### PR TITLE
feat: Add Share Recipe page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Footer from './components/Footer';
 import HomePage from './components/pages/HomePage';
 import LegalPage from './components/pages/LegalPage';
 import About from './components/pages/About';
+import SharePage from './components/pages/SharePage';
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
             <Route path="/" element={<HomePage />} />
             <Route path="/legal" element={<LegalPage />} />
             <Route path="/about" element={<About />} />
+            <Route path="/share/:recipeId" element={<SharePage />} />
           </Routes>
         </main>
         <Footer />

--- a/src/components/pages/SharePage.css
+++ b/src/components/pages/SharePage.css
@@ -1,0 +1,21 @@
+.share-page-container {
+  padding: 20px;
+  font-family: Arial, sans-serif;
+}
+
+.share-page-container h1 {
+  color: #333;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.share-page-container pre {
+  background-color: #f4f4f4;
+  border: 1px solid #ddd;
+  padding: 15px;
+  border-radius: 4px;
+  white-space: pre-wrap; /* Ensures long lines wrap */
+  word-wrap: break-word; /* Breaks words if necessary */
+  font-size: 0.9em;
+  color: #333;
+}

--- a/src/components/pages/SharePage.js
+++ b/src/components/pages/SharePage.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import './SharePage.css';
+
+const SharePage = () => {
+  const { recipeId } = useParams();
+  const [recipeData, setRecipeData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchRecipe = async () => {
+      try {
+        const response = await fetch(`https://menu-api-kappa.vercel.app/api/utilities/web?recipeId=${recipeId}`);
+        if (!response.ok) {
+          throw new Error('Failed to fetch recipe data');
+        }
+        const data = await response.json();
+        if (!data) {
+          throw new Error('No recipe data found');
+        }
+        setRecipeData(data);
+      } catch (err) {
+        setError(err.message);
+      }
+    };
+
+    if (recipeId) {
+      fetchRecipe();
+    }
+  }, [recipeId]);
+
+  if (error) {
+    return <div>Error: {error}</div>;
+  }
+
+  if (!recipeData) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className="share-page-container">
+      <h1>Recipe Details</h1>
+      <pre>{JSON.stringify(recipeData, null, 2)}</pre>
+    </div>
+  );
+};
+
+export default SharePage;


### PR DESCRIPTION
This commit introduces a new page at `/share/:recipeId` that allows you to view a recipe fetched from an external API.

The key changes include:
- A new `SharePage.js` component that fetches and displays recipe data.
- A new route in `App.js` to render the `SharePage` component.
- Basic styling for the `SharePage` component.